### PR TITLE
Update index.html to use mattermost invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,6 @@
                 Community
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="https://gitter.im/NSLS-II/DAMA">Ask for Help</a>
                 <a class="dropdown-item" href="https://github.com/bluesky">Github</a>
 		<a class="dropdown-item" href="https://mattermost.hzdr.de/signup_user_complete/?id=xr4bwecii7n6j8sj63ktqnk13a&md=link&sbr=su">Mattermost Chat</a>     
               </div>

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
                 <a class="dropdown-item" href="https://gitter.im/NSLS-II/DAMA">Ask for Help</a>
                 <a class="dropdown-item" href="https://github.com/bluesky">Github</a>
+		<a class="dropdown-item" href="https://mattermost.hzdr.de/signup_user_complete/?id=xr4bwecii7n6j8sj63ktqnk13a&md=link&sbr=su">Mattermost Chat</a>     
               </div>
             </li>
 


### PR DESCRIPTION
HZDR are hosting an instance of Mattermost for us to use. I have added the link to the dropdown menu "Community" in the docs on the suggestion of @danielballan 