### PR TITLE
DOC: update the link to point to the MyBinder tutorials

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
         Bluesky is a collection of Python libraries that are co-developed but
         independently useful and may be adopted <em>a la carte</em>.
       </p>
-      <a class="btn btn-lg btn-dark" href="https://try.nsls2.bnl.gov" role="button">Try Now &raquo;</a>
+      <a class="btn btn-lg btn-dark" href="https://mybinder.org/v2/gh/bluesky/tutorials/main?urlpath=lab" role="button">Try Now &raquo;</a>
     </div>
     <div class="product-device box-shadow d-none d-md-block"></div>
     <div class="product-device product-device-2 box-shadow d-none d-md-block"></div>


### PR DESCRIPTION
This PR fixes the unmaintained link https://try.nsls2.bnl.gov/.