### PR TITLE
enh: add adaptive to index

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,8 @@
               <a class="dropdown-item" href="https://bluesky.github.io/databroker">Data Broker &mdash; Data Storage</a>
               <a class="dropdown-item" href="https://bluesky.github.io/bluesky-widgets">Bluesky Widgets (beta)&mdash;
                 Graphical Components for Jupyter and Qt</a>
+              <a class="dropdown-item" href="https://bluesky.github.io/bluesky-adaptive">Bluesky Adaptive &mdash;
+                Tools for Adaptive and Autonomous Experiments</a>
               <a class="dropdown-item" href="https://bluesky.github.io/suitcase">Suitcase &mdash; Export /
                 Serialization</a>
               <a class="dropdown-item" href="https://bluesky.github.io/event-model">Event Model &mdash; Data Model &
@@ -68,9 +70,10 @@
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
               <a class="dropdown-item" href="https://github.com/bluesky">Github</a>
-	      <a class="dropdown-item" href="https://calendar.google.com/calendar/u/0/embed?src=7aolj23t540871bsu27ikei5i8@group.calendar.google.com&ctz=America/New_York">Calendar</a>
+              <a class="dropdown-item"
+                href="https://calendar.google.com/calendar/u/0/embed?src=7aolj23t540871bsu27ikei5i8@group.calendar.google.com&ctz=America/New_York">Calendar</a>
               <a class="dropdown-item" href="https://blueskyproject.io/mattermost/">Mattermost (Chat)</a>
-	      <a class="dropdown-item" href="https://github.com/bluesky/governance">Governance</a>
+              <a class="dropdown-item" href="https://github.com/bluesky/governance">Governance</a>
             </div>
           </li>
 
@@ -102,7 +105,8 @@
         Bluesky is a collection of Python libraries that are co-developed but
         independently useful and may be adopted <em>a la carte</em>.
       </p>
-      <a class="btn btn-lg btn-dark" href="https://mybinder.org/v2/gh/bluesky/tutorials/main?urlpath=lab" role="button">Try Now &raquo;</a>
+      <a class="btn btn-lg btn-dark" href="https://mybinder.org/v2/gh/bluesky/tutorials/main?urlpath=lab"
+        role="button">Try Now &raquo;</a>
     </div>
     <div class="product-device box-shadow d-none d-md-block"></div>
     <div class="product-device product-device-2 box-shadow d-none d-md-block"></div>
@@ -252,6 +256,22 @@ with DeviceCollector():
               </ul>
               <a class="btn btn-lg btn-dark" href="https://bluesky.github.io/bluesky-queueserver" role="button">Learn
                 about Bluesky Queue Server &raquo;</a>
+            </div>
+            <div class="col-md-5">
+            </div>
+          </div>
+          <hr class="featurette-divider" />
+          <div class="row">
+            <div class="col-md-7">
+              <h2>Bluesky Adaptive &mdash; Adaptive and Autonomous Experiments</h2>
+              <p class="lead "> Bluesky Adaptive provides a harness for embedding Agents
+                into experiment orchestration. </p>
+              <ul>
+                <li>Python <strong>API</strong> for building blocking and asynchronous agents.</li>
+                <li>REST API for Agent services to keep <strong>human in the loop</strong>.</li>
+              </ul>
+              <a class="btn btn-lg btn-dark" href="https://bluesky.github.io/bluesky-adaptive" role="button">Learn
+                about Bluesky Adaptive &raquo;</a>
             </div>
             <div class="col-md-5">
             </div>


### PR DESCRIPTION
We realized the other day that although the docs get published with CI to blueskyproject.io/bluesky-adaptive, they are not accessible via the index page. 