### PR TITLE
Blop remove (beta) tag in menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
               <a class="dropdown-item" href="https://bluesky.github.io/databroker">Data Broker &mdash; Data Storage</a>
               <a class="dropdown-item" href="https://bluesky.github.io/bluesky-widgets">Bluesky Widgets (beta)&mdash;
                 Graphical Components for Jupyter and Qt</a>
-			  <a class="dropdown-item" href="https://bluesky.github.io/blop">Blop (beta) &mdash;
+			  <a class="dropdown-item" href="https://bluesky.github.io/blop">Blop &mdash;
                 Bluesky optimization package</a>
               <a class="dropdown-item" href="https://bluesky.github.io/suitcase">Suitcase &mdash; Export /
                 Serialization</a>


### PR DESCRIPTION
No longer in beta: https://github.com/bluesky/blop/releases/tag/v1.0.0